### PR TITLE
Trigger table creation task on startup event, autocommit = True

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,10 +28,10 @@ class Task(BaseModel):
     description: str
 
 # Create a table for tasks (You can run this once outside of the app)
-@app.get("/api")
+@app.on_event("startup")
 def create_tasks_table():
     try:
-        conn = pyodbc.connect(connection_string)
+        conn = pyodbc.connect(connection_string, autocommit=True)
         cursor = conn.cursor()
         cursor.execute("""
             CREATE TABLE Tasks (
@@ -39,8 +39,7 @@ def create_tasks_table():
                 Title varchar(255),
                 Description text
             );
-        """)
-        conn.commit()        
+        """)      
     except Exception as e:
         print(e)
     return "Table Created... Tasks API Ready"


### PR DESCRIPTION
Trigger table creation task on startup event instead of get API to avoid first time manual hit. 
Use autocommit = True. Noticed issues with conn.commit() while creating DB/table from backend.